### PR TITLE
Add Lorin Hochstein to Twitter feeds of Chaos Engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,4 @@ Please take a look at the [contribution guidelines](CONTRIBUTING.md) first. Cont
 * [Tammy Bütow](https://twitter.com/tammybutow)
 * [Bruce Wong](https://twitter.com/bruce_m_wong)
 * [Kolton Andrus](https://twitter.com/koltonandrus)
+* [Lorin Hochstein](https://twitter.com/lhochstein)


### PR DESCRIPTION
I've added Lorin Hochstein, chaos engineer @Netflix and co-author of Chaos Engineering book, to the Twitter feed section.