### PR TITLE
Suggest to include PowerfulSeal in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,4 @@ Please take a look at the [contribution guidelines](CONTRIBUTING.md) first. Cont
 * [Charles Torre](https://twitter.com/carmine007)
 * [Russ Miles](https://twitter.com/russmiles)
 * [Aaron Rinehart](https://twitter.com/aaronrinehart)
+* [Mikolaj Pawlikowski](https://twitter.com/mikopawlikowski)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Please take a look at the [contribution guidelines](CONTRIBUTING.md) first. Cont
 * [Gremlin Inc.](https://www.gremlininc.com/) - Failure as a Service
 * [Pumba](https://github.com/gaia-adm/pumba) - Chaos testing and network emulation for Docker containers (and clusters)
 * [Chaos Toolkit](https://github.com/chaostoolkit/chaostoolkit) - A chaos engineering toolkit to help you build confidence in your software system.
+* [PowerfulSeal](https://github.com/bloomberg/powerfulseal) - adds chaos to your Kubernetes clusters, so that you can detect problems in your systems as early as possible. It kills targeted pods and takes VMs up and down.
 
 ## Papers
 * [Simple Testing Can Prevent Most Critical Failures: An Analysis of Production Failures in Distributed Data-Intensive Systems](https://www.usenix.org/system/files/conference/osdi14/osdi14-paper-yuan.pdf)


### PR DESCRIPTION
I would like to suggest to include [PowerfulSeal](https://github.com/bloomberg/powerfulseal) in the list:

> __PowerfulSeal__ adds chaos to your Kubernetes clusters, so that you can detect problems in your systems as early as possible. It kills targeted pods and takes VMs up and down.

Full disclosure: I'm the main contributor, and I presented the tool last week at [Kubecon 2017 North America](https://events.linuxfoundation.org/events/kubecon-and-cloudnativecon-north-america/program/schedule).


Tell me what you think :-)