### PR TITLE
Consider adding Pod-Reaper as a Notable Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Please take a look at the [contribution guidelines](CONTRIBUTING.md) first. Cont
 * [drax](https://github.com/dcos-labs/drax) -  DC/OS Resilience Automated Xenodiagnosis tool. It helps to test DC/OS deployments by applying a Chaos Monkey-inspired, proactive and invasive testing approach.
 * [Wiremock](http://wiremock.org/) - API mocking (Service Virtualization) which enables modeling real world faults and delays
 * [MockLab](http://get.mocklab.io/) - API mocking (Service Virtualization) as a service which enables modeling real world faults and delays
+* [Pod-Reaper](https://github.com/target/pod-reaper) - A rules based pod killing container. Pod-Reaper was designed to kill pods that meet specific conditions that can be used for Chaos testing in Kubernetes.
 
 ## Papers
 * [Simple Testing Can Prevent Most Critical Failures: An Analysis of Production Failures in Distributed Data-Intensive Systems](https://www.usenix.org/system/files/conference/osdi14/osdi14-paper-yuan.pdf)


### PR DESCRIPTION
Pod-Reaper is a Chaos Tool for killing pods in kubernetes.  Deploying a Pod Reaper to your kubernetes namespace is a great way to validate your application and micro services can be resilient to chaos kills.  Pod Reaper is designed using environment variables that can be configured to support the chaos you require for testing (once an hour, once a minute, % of pods, etc.).  Tool was authored by Github user murasaki/BrianBerzins.