### PR TITLE
add DiUS GameDay resources page

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Please take a look at the [contribution guidelines](CONTRIBUTING.md) first. Cont
 * [SysAdvent](https://sysadvent.blogspot.com) - One article for each day of December, ending on the 25th article.
 * [Gremlin Blog](https://blog.gremlininc.com) - Blogs on Chaos Engineering from Gremlin Inc.
 * [O’Reilly Systems Engineering and Operations Newsletter](http://www.oreilly.com/webops-perf/newsletter.html) - Weekly systems engineering and operations news and insights from industry insiders.
+* [GameDay Resources](dius.com.au/resources/game-day/) - Resources for getting started with GameDay and Chaos Engineering.
 
 ## Conferences & Meetups
 * [SRECon Conferences](https://www.usenix.org/conferences/byname/925) - The Official SRE Conference.


### PR DESCRIPTION
Contains a number of useful resources for getting started with GameDay's
and chaos engineering in general.