### PR TITLE
Adding drain tests (a new type of DR tests) published at OSDI

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ A curated list of awesome [Chaos Engineering](http://principlesofchaos.org/) res
 * [Azure Fault Analysis Service](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-testability-overview), see also [Include controlled Chaos in Service Fabric clusters](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-controlled-chaos)
 
 ## Papers
+* [Maelstrom: Mitigating Datacenter-level Disasters by Draining Interdependent Traffic Safely and Efficiently](https://www.usenix.org/system/files/osdi18-veeraraghavan.pdf)
 * [Simple Testing Can Prevent Most Critical Failures: An Analysis of Production Failures in Distributed Data-Intensive Systems](https://www.usenix.org/system/files/conference/osdi14/osdi14-paper-yuan.pdf)
 * [Lineage-driven Fault Injection](https://people.eecs.berkeley.edu/~palvaro/molly.pdf)
 * [Automating Failure Testing Research at Internet Scale ](https://people.ucsc.edu/~palvaro/fit-ldfi.pdf)


### PR DESCRIPTION
The Maelstrom paper at OSDI'18 describes how Facebook runs a new type of DR (Disaster Recover) tests called _drain tests_ as well as the tooling and experiences that automate continuous drain tests. The same tooling is used in mitigating real datacenter-level disasters just like running a drain test.