### PR TITLE
Remove paper on lineage-driven Fault Injection 

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ A curated list of awesome [Chaos Engineering](http://principlesofchaos.org/) res
 ## Papers
 * [Maelstrom: Mitigating Datacenter-level Disasters by Draining Interdependent Traffic Safely and Efficiently](https://www.usenix.org/system/files/osdi18-veeraraghavan.pdf)
 * [Simple Testing Can Prevent Most Critical Failures: An Analysis of Production Failures in Distributed Data-Intensive Systems](https://www.usenix.org/system/files/conference/osdi14/osdi14-paper-yuan.pdf)
-* [Lineage-driven Fault Injection](https://people.eecs.berkeley.edu/~palvaro/molly.pdf)
 * [Automating Failure Testing Research at Internet Scale ](https://people.ucsc.edu/~palvaro/fit-ldfi.pdf)
 * [Principles of Antifragile Software](https://arxiv.org/abs/1404.3056)
 * [Why is random testing effective for partition tolerance bugs?](https://dl.acm.org/citation.cfm?id=3177123.3158134)


### PR DESCRIPTION
Unfortunately, the paper on Lineage-driven Fault Injection (https://people.eecs.berkeley.edu/~palvaro/molly.pdf) is no longer available, it results in a resource not found.