### PR TITLE
Adding Link to Chaos Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ A curated list of awesome [Chaos Engineering](http://principlesofchaos.org/) res
 * [Chaos Lemur](https://github.com/strepsirrhini-army/chaos-lemur) - A self-hostable application to randomly destroy virtual machines in a BOSH-managed environment
 * [Simoorg](https://github.com/linkedin/simoorg) - Linkedin’s very own failure inducer framework.
 * [react-chaos](https://github.com/jchiatt/react-chaos) - A chaos engineering tool for your React apps
-
+* [Chaos Engine](https://github.com/ThalesGroup/chaos-engine) - tool designed to intermittently destroy or degrade application resources running in cloud based infrastructure. [Documentation](https://thalesgroup.github.io/chaos-engine/)
 
 ## Cloud Services
 * [Testing Amazon Aurora Using Fault Injection Queries](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Managing.html#AuroraMySQL.Managing.FaultInjectionQueries)


### PR DESCRIPTION
Chaos Engine is an application for creating random Chaos Events in cloud applications to test resiliency. It follows the Principles of Chaos to create random faults (experiments) that could reasonably occur in a real application deployment.

Chaos Engine makes intelligent decisions in how and when to create experiments. When properly configured, experiments can be restricted to occur only during normal business hours (i.e., no pager alerts).

Chaos Engine currently supports Amazon Web Services, Pivotal Cloud Foundry, and Kubernetes. We have future plans to add support for Google Cloud Platform.