### PR TITLE
Add OpenShift Kraken Chaos tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ A curated list of awesome [Chaos Engineering](http://principlesofchaos.org/) res
 * [Proofdock's Chaos Engineering Platform](https://proofdock.io) - A chaos engineering platform that seamlessly integrates in Azure DevOps and has a focus on the Azure cloud platform.
 * [Pystol](https://www.pystol.org/docs) - Pystol is a fault injection platform allowing users to execute fault injection Actions in cloud-native environments in a controlled and prescribed way.
 * [AWSSSMChaosRunner](https://github.com/amzn/awsssmchaosrunner) - Amazon's light-weight open-source library for chaos engineering on AWS. It can be used for [EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html), [ECS (with EC2 launch type)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/getting-started-ecs-ec2.html) and [Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/getting-started-fargate.html).
+* [kraken](https://github.com/openshift-scale/kraken) - Chaos and resiliency testing tool for Kubernetes and OpenShift.
 
 ## Retired tools
 * [The Simian Army](https://github.com/Netflix/SimianArmy) - A suite of tools for keeping your cloud operating in top form.


### PR DESCRIPTION
**Context**:
Adding [Kraken](https://github.com/openshift-scale/kraken) - a Chaos and resiliency testing tool for Kubernetes and OpenShift.

**Descirption**:
Kraken injects deliberate failures into Kubernetes/OpenShift clusters to check if it is resilient to failures.