### PR TITLE
Add Chaos Frontend Toolkit to the list of tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ A curated list of awesome [Chaos Engineering](http://principlesofchaos.org/) res
 * [Chaos Experimentation Framework](https://github.com/lyft/clutch) - An extensible platform for infrastructure management including Chaos Engineering 
 * [NetHavoc](https://www.cavisson.com/nethavoc-resilience-testing-solution/) - A Chaos Engineering Tool for Linux, K8s, Windows, PCF, Cloud, and Containers for injecting Resource, Infrastructure, Network, and Application failures.
 * [gorm-sqlchaos](https://github.com/u2386/gorm-sqlchaos) - A runtime SQL manipulator for your Golang applications based on gorm.
+* [Chaos Frontend Toolkit](https://chaos-frontend-toolkit.web.app/) - A set of tools to apply Chaos Engineering to frontend
 
 ## Retired tools
 * [The Simian Army](https://github.com/Netflix/SimianArmy) - A suite of tools for keeping your cloud operating in top form.


### PR DESCRIPTION
This PR adds Chaos Frontend Toolkit to the list of tools.

Chaos Frontend Toolkit is a browser extension (Chrome, FF, Edge) that applies Chaos Engineering experiments to web apps.

The experiments cover network, timers, history, accessibility, localization, inputs, ...

(Re-opened from #114 after a failed rebase)