### PR TITLE
Add `xk6-disruptor` to the list of notable tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ A curated list of awesome [Chaos Engineering](http://principlesofchaos.org/) res
 * [gorm-sqlchaos](https://github.com/u2386/gorm-sqlchaos) - A runtime SQL manipulator for your Golang applications based on gorm.
 * [Chaos Frontend Toolkit](https://chaos-frontend-toolkit.web.app/) - A set of tools to apply Chaos Engineering to frontend
 * [Mitigant](https://mitigant.io/) - The Continuos Security Verification Platform, enables confidence in cloud security posture by leveraging security chaos engineering.
+* [xk6-disruptor](https://github.com/grafana/xk6-disruptor) - A k6 extension to inject faults from [k6 scripts](https://github.com/grafana/k6).
 
 ## Retired tools
 * [The Simian Army](https://github.com/Netflix/SimianArmy) - A suite of tools for keeping your cloud operating in top form.


### PR DESCRIPTION
Added:

> * [xk6-disruptor](https://github.com/grafana/xk6-disruptor) - A k6 extension to inject faults from [k6 scripts](https://github.com/grafana/k6).